### PR TITLE
Fix for different versions of cargo-pgrx using different RELKIND_SEQUENCE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.14.3"
+pgrx = "=0.15.0"
 regex = "1.11.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.14.3"
+pgrx-tests = "=0.15.0"
 
 [profile.dev]
 panic = "unwind"

--- a/src/guc.rs
+++ b/src/guc.rs
@@ -1,7 +1,7 @@
 // Register the GUC parameters for the extension
 
 use pgrx::{GucContext, GucFlags, GucRegistry, GucSetting, PostgresGucEnum};
-use std::ffi::CStr;
+use std::ffi::{CString};
 
 #[derive(PostgresGucEnum, Clone, Copy, PartialEq, Debug)]
 pub enum DetectionLevelEnum {
@@ -13,71 +13,71 @@ pub enum DetectionLevelEnum {
 pub static PG_NO_SEQSCAN_LEVEL: GucSetting<DetectionLevelEnum> =
     GucSetting::<DetectionLevelEnum>::new(DetectionLevelEnum::Error);
 
-pub static PG_NO_SEQSCAN_CHECK_DATABASES: GucSetting<Option<&'static CStr>> =
-    GucSetting::<Option<&'static CStr>>::new(Some(c""));
+pub static PG_NO_SEQSCAN_CHECK_DATABASES: GucSetting<Option<CString>> =
+    GucSetting::<Option<CString>>::new(Some(c""));
 
-pub static PG_NO_SEQSCAN_CHECK_SCHEMAS: GucSetting<Option<&'static CStr>> =
-    GucSetting::<Option<&'static CStr>>::new(Some(c"public"));
+pub static PG_NO_SEQSCAN_CHECK_SCHEMAS: GucSetting<Option<CString>> =
+    GucSetting::<Option<CString>>::new(Some(c"public"));
 
-pub static PG_NO_SEQSCAN_IGNORE_USERS: GucSetting<Option<&'static CStr>> =
-    GucSetting::<Option<&'static CStr>>::new(Some(c""));
+pub static PG_NO_SEQSCAN_IGNORE_USERS: GucSetting<Option<CString>> =
+    GucSetting::<Option<CString>>::new(Some(c""));
 
-pub static PG_NO_SEQSCAN_IGNORE_TABLES: GucSetting<Option<&'static CStr>> =
-    GucSetting::<Option<&'static CStr>>::new(Some(c""));
+pub static PG_NO_SEQSCAN_IGNORE_TABLES: GucSetting<Option<CString>> =
+    GucSetting::<Option<CString>>::new(Some(c""));
 
-pub static PG_NO_SEQSCAN_CHECK_TABLES: GucSetting<Option<&'static CStr>> =
-    GucSetting::<Option<&'static CStr>>::new(Some(c""));
+pub static PG_NO_SEQSCAN_CHECK_TABLES: GucSetting<Option<CString>> =
+    GucSetting::<Option<CString>>::new(Some(c""));
 
 pub fn register_gucs() {
     GucRegistry::define_enum_guc(
-        "pg_no_seqscan.level",
-        "Detection level for sequential scans",
-        "Error: query failed on seqscan - Warn: a notice is displayed on seqscan - Off: detection skipped",
+        c"pg_no_seqscan.level",
+        c"Detection level for sequential scans",
+        c"Error: query failed on seqscan - Warn: a notice is displayed on seqscan - Off: detection skipped",
         &PG_NO_SEQSCAN_LEVEL,
         GucContext::Userset,
         GucFlags::default(),
     );
 
     GucRegistry::define_string_guc(
-        "pg_no_seqscan.check_databases",
-        "Databases to check seqscan for, comma separated",
-        "If empty, all databases will be checked",
+        c"pg_no_seqscan.check_databases",
+        c"Databases to check seqscan for, comma separated",
+        c"If empty, all databases will be checked",
         &PG_NO_SEQSCAN_CHECK_DATABASES,
         GucContext::Suset,
         GucFlags::SUPERUSER_ONLY,
     );
 
     GucRegistry::define_string_guc(
-        "pg_no_seqscan.check_schemas",
-        "Schemas to check seqscan for, comma separated",
-        "If empty, all schemas will be checked",
+        c"pg_no_seqscan.check_schemas",
+        c"Schemas to check seqscan for, comma separated",
+        c"If empty, all schemas will be checked",
         &PG_NO_SEQSCAN_CHECK_SCHEMAS,
         GucContext::Suset,
         GucFlags::SUPERUSER_ONLY,
     );
 
     GucRegistry::define_string_guc(
-        "pg_no_seqscan.check_tables",
-        "Tables to check seqscan for, comma separated",
-        "If empty, all tables will be checked",
+        c"pg_no_seqscan.check_tables",
+        c"Tables to check seqscan for, comma separated",
+        c"If empty, all tables will be checked",
         &PG_NO_SEQSCAN_CHECK_TABLES,
         GucContext::Suset,
         GucFlags::SUPERUSER_ONLY,
     );
 
     GucRegistry::define_string_guc(
-        "pg_no_seqscan.ignore_users",
-        "Users to ignore, comma separated",
-        "",
+        c"pg_no_seqscan.ignore_users",
+        c"Users to ignore, comma separated",
+        c"",
         &PG_NO_SEQSCAN_IGNORE_USERS,
         GucContext::Suset,
         GucFlags::SUPERUSER_ONLY,
     );
 
     GucRegistry::define_string_guc(
-        "pg_no_seqscan.ignore_tables",
-        "Tables to ignore, comma separated",
-        "This setting is ignored if some tables are declared in `check_tables`",
+        c"pg_no_seqscan.ignore_tables",
+        c"Tables to ignore, comma separated",
+        c"This setting is ignored if some tables are declared in `check_tables`",
         &PG_NO_SEQSCAN_IGNORE_TABLES,
         GucContext::Suset,
         GucFlags::SUPERUSER_ONLY,

--- a/src/guc.rs
+++ b/src/guc.rs
@@ -1,7 +1,7 @@
 // Register the GUC parameters for the extension
 
 use pgrx::{GucContext, GucFlags, GucRegistry, GucSetting, PostgresGucEnum};
-use std::ffi::{CString};
+use std::ffi::CString;
 
 #[derive(PostgresGucEnum, Clone, Copy, PartialEq, Debug)]
 pub enum DetectionLevelEnum {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,9 +1,14 @@
 use pgrx::pg_sys;
 use pgrx::pg_sys::{get_namespace_name, get_rel_name, get_rel_namespace, rt_fetch, List, Oid};
-use std::ffi::{c_char, CStr};
+use std::ffi::{c_char, CStr, CString};
 
-pub fn extract_comma_separated_setting(comma_separated_string: &CStr) -> std::str::Split<'_, char> {
-    comma_separated_string.to_str().unwrap().split(',')
+pub fn extract_comma_separated_setting(comma_separated_string: CString) -> Vec<String> {
+    comma_separated_string
+        .to_str()
+        .unwrap()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .collect()
 }
 
 pub unsafe fn string_from_ptr(ptr: *const c_char) -> Option<String> {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -10,6 +10,9 @@ pub fn extract_comma_separated_setting(comma_separated_string: CString) -> Vec<S
         .map(|s| s.trim().to_string())
         .collect()
 }
+pub fn comma_separated_list_contains(comma_separated_string: CString, value: String) -> bool {
+    extract_comma_separated_setting(comma_separated_string).contains(&value)
+}
 
 pub unsafe fn string_from_ptr(ptr: *const c_char) -> Option<String> {
     match CStr::from_ptr(ptr).to_str() {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 
 use crate::guc::DetectionLevelEnum;
 use crate::helpers::{
-    current_db_name, current_username, extract_comma_separated_setting, resolve_namespace_name,
+    comma_separated_list_contains, current_db_name, current_username, resolve_namespace_name,
     resolve_table_name, scanned_table,
 };
 use std::ffi::CStr;
@@ -81,10 +81,9 @@ Query: {}
 
     fn is_ignored_user(&mut self, current_user: String) -> bool {
         match guc::PG_NO_SEQSCAN_IGNORE_USERS.get() {
-            Some(ignore_users_setting) => extract_comma_separated_setting(ignore_users_setting)
-                .iter()
-                .find(|ignore_user| current_user == **ignore_user)
-                .is_some(),
+            Some(ignore_users_setting) => {
+                comma_separated_list_contains(ignore_users_setting, current_user)
+            }
             None => unreachable!(),
         }
     }
@@ -93,10 +92,7 @@ Query: {}
         match guc::PG_NO_SEQSCAN_CHECK_DATABASES.get() {
             Some(check_databases_setting) => {
                 check_databases_setting.is_empty()
-                    || extract_comma_separated_setting(check_databases_setting)
-                        .iter()
-                        .find(|check_database| database == **check_database)
-                        .is_some()
+                    || comma_separated_list_contains(check_databases_setting, database)
             }
             None => unreachable!(),
         }
@@ -106,10 +102,7 @@ Query: {}
         match guc::PG_NO_SEQSCAN_CHECK_SCHEMAS.get() {
             Some(check_schemas_setting) => {
                 check_schemas_setting.is_empty()
-                    || extract_comma_separated_setting(check_schemas_setting)
-                        .iter()
-                        .find(|check_schema: &&String| schema == **check_schema)
-                        .is_some()
+                    || comma_separated_list_contains(check_schemas_setting, schema)
             }
             None => unreachable!(),
         }
@@ -125,10 +118,7 @@ Query: {}
         match guc::PG_NO_SEQSCAN_CHECK_TABLES.get() {
             Some(check_tables_setting) => {
                 check_tables_setting.is_empty()
-                    || extract_comma_separated_setting(check_tables_setting)
-                        .iter()
-                        .find(|check_table| table_name == **check_table)
-                        .is_some()
+                    || comma_separated_list_contains(check_tables_setting, table_name)
             }
             None => unreachable!(),
         }
@@ -136,10 +126,9 @@ Query: {}
 
     fn is_ignored_table(&mut self, table_name: String) -> bool {
         match guc::PG_NO_SEQSCAN_IGNORE_TABLES.get() {
-            Some(ignore_tables_setting) => extract_comma_separated_setting(ignore_tables_setting)
-                .iter()
-                .find(|ignore_table| table_name == **ignore_table)
-                .is_some(),
+            Some(ignore_tables_setting) => {
+                comma_separated_list_contains(ignore_tables_setting, table_name)
+            }
             None => unreachable!(),
         }
     }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -82,7 +82,9 @@ Query: {}
     fn is_ignored_user(&mut self, current_user: String) -> bool {
         match guc::PG_NO_SEQSCAN_IGNORE_USERS.get() {
             Some(ignore_users_setting) => extract_comma_separated_setting(ignore_users_setting)
-                .iter().find(|ignore_user| current_user == **ignore_user).is_some(),
+                .iter()
+                .find(|ignore_user| current_user == **ignore_user)
+                .is_some(),
             None => unreachable!(),
         }
     }
@@ -92,7 +94,9 @@ Query: {}
             Some(check_databases_setting) => {
                 check_databases_setting.is_empty()
                     || extract_comma_separated_setting(check_databases_setting)
-                        .iter().find(|check_database| database == **check_database).is_some()
+                        .iter()
+                        .find(|check_database| database == **check_database)
+                        .is_some()
             }
             None => unreachable!(),
         }
@@ -103,7 +107,9 @@ Query: {}
             Some(check_schemas_setting) => {
                 check_schemas_setting.is_empty()
                     || extract_comma_separated_setting(check_schemas_setting)
-                        .iter().find(|check_schema: &&String| schema == **check_schema).is_some()
+                        .iter()
+                        .find(|check_schema: &&String| schema == **check_schema)
+                        .is_some()
             }
             None => unreachable!(),
         }
@@ -120,7 +126,9 @@ Query: {}
             Some(check_tables_setting) => {
                 check_tables_setting.is_empty()
                     || extract_comma_separated_setting(check_tables_setting)
-                        .iter().find(|check_table| table_name == **check_table).is_some()
+                        .iter()
+                        .find(|check_table| table_name == **check_table)
+                        .is_some()
             }
             None => unreachable!(),
         }
@@ -129,7 +137,9 @@ Query: {}
     fn is_ignored_table(&mut self, table_name: String) -> bool {
         match guc::PG_NO_SEQSCAN_IGNORE_TABLES.get() {
             Some(ignore_tables_setting) => extract_comma_separated_setting(ignore_tables_setting)
-                .iter().find(|ignore_table| table_name == **ignore_table).is_some(),
+                .iter()
+                .find(|ignore_table| table_name == **ignore_table)
+                .is_some(),
             None => unreachable!(),
         }
     }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -175,7 +175,7 @@ Query: {}
     fn is_sequence(&self, relation_oid: Oid) -> bool {
         unsafe {
             let relation = PgRelation::open(relation_oid);
-            (*relation.rd_rel).relkind == (pg_sys::RELKIND_SEQUENCE as i8)
+            (*relation.rd_rel).relkind == (pg_sys::RELKIND_SEQUENCE as u8)
         }
     }
 }


### PR DESCRIPTION
Previously, the build of pgrx failed for certain versions of pg15 due to the following error:

```
517.0    --> src/hooks.rs:178:43
517.0     |
517.0 178 |             (*relation.rd_rel).relkind == (pg_sys::RELKIND_SEQUENCE as i8)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
```

This PR fixes the issue by updating `cargo-pgrx` to `0.15.0` that defines a unified value for `RELKIND_SEQUENCE = c_char`.

The update of cargo-pgrx comes with changes in the signature of `define_enum_guc`. This PR adapt the code to comply with those changes.

Other cosmetic changes:

- Adds comma_separated_list_contains function to check if a value is contained in a comma separated list.

