### PR TITLE
doc: avoid perf degradation because of jit

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ shared_preload_libraries = 'pg_no_seqscan.so' # Load pg_no_seqscan extension (or
 
 enable_seqscan = 'off'                        # Discourage seqscans
 
-jit_above_cost = 8e+11                        # Avoids performance degradation by discouraging jit.
+jit_above_cost = 800000000000                 # Avoids performance degradation by discouraging jit.
                                               # Indeed `enable_seqscan = off` increases strongly the cost and could suggest 
                                               # pg to use jit.
                                               # It should be > {max tables or partitions scanned in on query + 1}*1e+10

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ shared_preload_libraries = 'pg_no_seqscan.so' # Load pg_no_seqscan extension (or
 
 enable_seqscan = 'off'                        # Discourage seqscans
 
-jit_above_cost = 8e+11                        # Avoids to use jit on each query, as the cost becomes much higher with
-                                              # enable_seqscan off.
+jit_above_cost = 8e+11                        # Avoids performance degradation by discouraging jit.
+                                              # Indeed `enable_seqscan = off` increases strongly the cost and could suggest 
+                                              # pg to use jit.
                                               # It should be > {max tables or partitions scanned in on query + 1}*1e+10
 
 # Optional settings for pg_no_seqscan:

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ shared_preload_libraries = 'pg_no_seqscan.so' # Load pg_no_seqscan extension (or
 enable_seqscan = 'off'                        # Discourage seqscans
 
 jit_above_cost = 800000000000                 # Avoids performance degradation by discouraging jit.
-                                              # Indeed `enable_seqscan = off` increases strongly the cost and could suggest 
-                                              # pg to use jit.
+                                              # Indeed `enable_seqscan = off` increases strongly the cost 
+                                              # and could encourage PG to use jit.
                                               # It should be > {max tables or partitions scanned in on query + 1}*1e+10
 
 # Optional settings for pg_no_seqscan:

--- a/README.md
+++ b/README.md
@@ -47,10 +47,13 @@ cargo pgrx install -c $(which pg_config)
 
 ```
 # Required settings for pg_no_seqscan:
-shared_preload_libraries = 'pg_no_seqscan.so' # load pg_no_seqscan extension (or .dylib file on mac os)
-enable_seqscan = 'off'                        # discourage seqscans
-jit_above_cost = 40000000000                  # avoids to use jit on each query, as the cost becomes much higher with
-                                              # enable_seqscan off
+shared_preload_libraries = 'pg_no_seqscan.so' # Load pg_no_seqscan extension (or .dylib file on mac os)
+
+enable_seqscan = 'off'                        # Discourage seqscans
+
+jit_above_cost = 8e+11                        # Avoids to use jit on each query, as the cost becomes much higher with
+                                              # enable_seqscan off.
+                                              # It should be > {max tables or partitions scanned in on query + 1}*1e+10
 
 # Optional settings for pg_no_seqscan:
 #pg_no_seqscan.check_databases = ''           # Databases to check seqscan for, comma separated.


### PR DESCRIPTION
As pg_no_seqscan extension needs `enable_seqscan = off` the average cost of queries increases strongly.
When working on partition tables with many partition or when join many tables, the cost was big enough to let PG enable jit which is rarely a good choice in terms of performance for local/test/ci database.

`jit_above_cost` was already set very high, but it's not enough for some specific use cases.

Here we increase the recommendation.