### PR TITLE
refactor: fix some issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ pg_test = []
 [dependencies]
 pgrx = "0.16.1"
 regex = "1.11.1"
+itertools = "0.14.0"
 
 [dev-dependencies]
 pgrx-tests = "0.16.1"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ that could cause dramatic performance degradation in production.
 ### Build the extension
 
 For now, you need to build the extension locally:
-`cargo build -r`
+`cargo build --release`
 That will generate the following files:
 
 - control file: pg_no_seqscan.control

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,10 +1,9 @@
 use pgrx::pg_sys::{
-    get_database_name, get_namespace_name,
-    get_rel_name,
-    get_rel_namespace, rt_fetch, GetUserId, GetUserNameFromId, List, MyDatabaseId, Oid,
+    GetUserId, GetUserNameFromId, List, MyDatabaseId, Oid, get_database_name, get_namespace_name,
+    get_rel_name, get_rel_namespace, rt_fetch,
 };
 use pgrx::{PgRelation, Spi};
-use std::ffi::{c_char, CStr, CString};
+use std::ffi::{CStr, CString, c_char};
 
 pub fn comma_separated_list_contains(comma_separated_string: CString, value: &str) -> bool {
     comma_separated_string

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -3,9 +3,9 @@ use pgrx::pg_sys::{
     get_rel_name, get_rel_namespace, rt_fetch,
 };
 use pgrx::{PgRelation, Spi};
-use std::ffi::{CStr, CString, c_char};
+use std::ffi::{CStr, c_char};
 
-pub fn comma_separated_list_contains(comma_separated_string: CString, value: &str) -> bool {
+pub fn comma_separated_list_contains(comma_separated_string: &CStr, value: &str) -> bool {
     comma_separated_string
         .to_str()
         .unwrap_or_default()
@@ -14,10 +14,7 @@ pub fn comma_separated_list_contains(comma_separated_string: CString, value: &st
 }
 
 pub fn string_from_ptr(ptr: *const c_char) -> Option<String> {
-    match unsafe { CStr::from_ptr(ptr).to_str() } {
-        Ok(str_value) => Some(str_value.to_string()),
-        Err(_) => None,
-    }
+    unsafe { CStr::from_ptr(ptr).to_str().ok().map(String::from) }
 }
 
 pub fn scanned_table(scanrelid: u32, rtables: *mut List) -> Option<Oid> {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -8,7 +8,7 @@ use std::ffi::{CStr, c_char};
 pub fn comma_separated_list_contains(comma_separated_string: &CStr, value: &str) -> bool {
     comma_separated_string
         .to_str()
-        .unwrap_or_default()
+        .expect("comma_separated_list_contains: Invalid UTF-8 sequence")
         .split(',')
         .any(|s| s.trim() == value)
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -13,15 +13,11 @@ pub fn comma_separated_list_contains(comma_separated_string: &CStr, value: &str)
         .any(|s| s.trim() == value)
 }
 
-pub fn string_from_ptr(ptr: *const c_char) -> Option<String> {
-    unsafe { CStr::from_ptr(ptr).to_str().ok().map(String::from) }
-}
-
 fn ptr_to_option_string(ptr: *const c_char) -> Option<String> {
     if ptr.is_null() {
         None
     } else {
-        string_from_ptr(ptr)
+        unsafe { CStr::from_ptr(ptr).to_str().ok().map(String::from) }
     }
 }
 
@@ -40,13 +36,13 @@ pub fn resolve_table_name(table_oid: Oid) -> Option<String> {
 pub fn current_db_name() -> String {
     unsafe {
         let db_oid = MyDatabaseId;
-        string_from_ptr(get_database_name(db_oid)).expect("Failed to get database name")
+        ptr_to_option_string(get_database_name(db_oid)).expect("Failed to get database name")
     }
 }
 
 pub fn current_username() -> String {
     let current_user = unsafe { GetUserNameFromId(GetUserId(), true) };
-    string_from_ptr(current_user).expect("Failed to get username")
+    ptr_to_option_string(current_user).expect("Failed to get username")
 }
 
 pub fn get_parent_table_oid(table_oid: Oid) -> Option<Oid> {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -17,26 +17,24 @@ pub fn string_from_ptr(ptr: *const c_char) -> Option<String> {
     unsafe { CStr::from_ptr(ptr).to_str().ok().map(String::from) }
 }
 
+fn ptr_to_option_string(ptr: *const c_char) -> Option<String> {
+    if ptr.is_null() {
+        None
+    } else {
+        string_from_ptr(ptr)
+    }
+}
+
 pub fn scanned_table(scanrelid: u32, rtables: *mut List) -> Option<Oid> {
     unsafe { rt_fetch(scanrelid, rtables).as_ref().map(|rte| rte.relid) }
 }
 
 pub fn resolve_namespace_name(oid: Oid) -> Option<String> {
-    let namespace_name = unsafe { get_namespace_name(get_rel_namespace(oid)) };
-    if namespace_name.is_null() {
-        None
-    } else {
-        string_from_ptr(namespace_name)
-    }
+    ptr_to_option_string(unsafe { get_namespace_name(get_rel_namespace(oid)) })
 }
 
 pub fn resolve_table_name(table_oid: Oid) -> Option<String> {
-    let relname_ptr = unsafe { get_rel_name(table_oid) };
-    if relname_ptr.is_null() {
-        return None;
-    }
-
-    string_from_ptr(relname_ptr)
+    ptr_to_option_string(unsafe { get_rel_name(table_oid) })
 }
 
 pub fn current_db_name() -> String {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -19,8 +19,7 @@ use pgrx::{PgBox, PgRelation, error, notice, pg_guard, pg_sys};
 use regex::Regex;
 use std::cell::RefCell;
 use std::collections::BTreeSet;
-use std::ffi::CStr;
-use std::os::raw::c_char;
+use std::ffi::{CStr, c_char};
 use std::sync::LazyLock;
 
 pub struct NoSeqscanHooks {


### PR DESCRIPTION
- inline extract_comma_separated_setting function
- use references in comma_separated_list_contains
- simplify string_from_ptr & ptr_to_option_string
- simplify some functions by removing unused params
- simplify functions resolve_namespace_name, resolve_table_name, current_db_name, current_username
- upgrade static mut
- optimise tables_in_seqscans by moving to BTreeSet (already ordered)
- better cast