### PR TITLE
feat; Add CODEOWNERS file for repository ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @doctolib/pg-no-seqscan


### PR DESCRIPTION
This pull request adds a new entry to the `CODEOWNERS` file to assign ownership of all files to the `@doctolib/pg-no-seqscan` team.

- Added `@doctolib/pg-no-seqscan` as the code owner for all files in the repository in `CODEOWNERS`.